### PR TITLE
Stop using global @ARGS within run_query()

### DIFF
--- a/bin/tdsql
+++ b/bin/tdsql
@@ -389,7 +389,7 @@ my $db = TDSQL->new($HOSTNAME, $USERNAME, $PASSWORD);
    $db->output($OUTPUT) if has_value($OUTPUT);
    $db->format($FORMAT) if has_value($FORMAT);
 if($SQL) {
-    eval { $db->run_query($SQL) };
+    eval { $db->run_query($SQL, @ARGS) };
     if(my $errstr = $@) {
         $db->finish;
         chomp $errstr;
@@ -576,7 +576,7 @@ sub run_query {
     my $output = $self->{output};
     my $format = $self->{format} || 'text';
     my $out = TDSQL::Outputter::text->new($output, $format);
-    $sth->execute(@ARGS) || die $DBI::errstr;
+    $sth->execute(@args) || die $DBI::errstr;
     my $started = 0;
     while(my $row = $sth->fetchrow_arrayref) {
         unless($started) {


### PR DESCRIPTION
A minor refactoring to make logic for handling of placeholder variables clearer.

tdsql can be evoked with placeholder variables from the command line, as in the following example:

```
tdsql 'SELECT * FROM userprefs WHERE username = ? AND prefname LIKE ?' 'johndoe' 'email.%'
```

Currently `run_query()` runs this by invisibly referencing the global `@ARGS` variable that is parsed during command line argument parsing, and it ignores any local `@args` passed in by the caller. This coincidentally doesn't matter because if `@ARGS` is populated, we are in a top-level code block where we only ever run a single command; but this change makes the logic clearer and removes the invisible use of global `@ARGS`.